### PR TITLE
Implemented ability to run without subcommands

### DIFF
--- a/examples/koimain_example.sh
+++ b/examples/koimain_example.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+source ../koi
+koiname=koimain_example
+koidescription="examples of running with subcommands"
+
+function __koimain {
+	__addarg "-h" "--help" "help" "optional" "" "test help message"
+	__addarg "-m" "--myval" "storevalue" "optional" "abc" "myval"
+	__addarg "" "myarg" "positionalvalue" "optional" "" "myarg"
+	__addarg "-f" "--myflag" "flag" "optional" "" "myflag"
+	__parseargs "$@"
+
+	echo "myval: $myval"
+	echo "myarg: $myarg"
+	echo "myflag: $myflag"
+}
+
+__koirun "$@"

--- a/examples/koimain_example.sh
+++ b/examples/koimain_example.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 set -e
 
-source ../koi
-koiname=koimain_example
-koidescription="examples of running with subcommands"
+source koi
+koiname=koimain_example.sh
+koidescription="Examples of running koi without subcommands via __koimain"
 
 function __koimain {
-	__addarg "-h" "--help" "help" "optional" "" "test help message"
-	__addarg "-m" "--myval" "storevalue" "optional" "abc" "myval"
-	__addarg "" "myarg" "positionalvalue" "optional" "" "myarg"
-	__addarg "-f" "--myflag" "flag" "optional" "" "myflag"
+	__addarg "-h" "--help" "help" "optional" "" "$koidescription"
+	__addarg "-m" "--myval" "storevalue" "optional" "abc" "An optional argument"
+	__addarg "" "myarg" "positionalvalue" "optional" "" "An optional positional argument"
+	__addarg "-f" "--myflag" "flag" "optional" "" "An optional flag"
 	__parseargs "$@"
 
 	echo "myval: $myval"

--- a/koi
+++ b/koi
@@ -424,7 +424,7 @@ function __parseargs {
 				local subcommandcmd="${FUNCNAME[1]} "
 				local subcommandhelptext="\n${helptexts[$index]}"
 			fi
-			output="${output}${subcommandindent}${coloryellow}${koiname}${subcommandcmd} ${argumentshelptext}${positionalhelptext}${colorreset}${subcommandhelptext}\n"
+			output="${output}${subcommandindent}${coloryellow}${koiname} ${subcommandcmd}${argumentshelptext}${positionalhelptext}${colorreset}${subcommandhelptext}\n"
 			for i in "${!shortoptions[@]}" ; do
 				if [[ "${actions[$i]}" == "help" ]] ; then
 					continue

--- a/koi
+++ b/koi
@@ -5,6 +5,7 @@ set -e
 koiname=koi
 koidescription="Bashful argument parsing"
 koicolors=1
+koisubcommands=1
 shortoptions=( )
 longoptions=( )
 actions=( )
@@ -40,6 +41,7 @@ function help {
 		fi
 	done
 
+	# setup colors
 	local colorteal=
 	local coloryellow=
 	local colorreset=
@@ -48,6 +50,23 @@ function help {
 		coloryellow='\033[93m'
 		colorreset='\033[0m'
 	fi
+
+	# build help menu
+	local helpoutput=
+
+	# if using __koimain
+	if declare -F -- "__koimain" >/dev/null ; then
+		helpoutput=$(cat <<- EndOfHelp
+		${coloryellow}${koidescription}${colorreset}
+
+		${colorteal}Usage:${colorreset}
+		`__cleararglists ; __koimain --help`
+		EndOfHelp
+		)
+	fi
+	echo -e "$helpoutput"
+	echo
+	exit
 
 	local helpoutput=$(cat <<- EndOfHelp
 	${coloryellow}${koidescription}${colorreset}
@@ -412,7 +431,14 @@ function __parseargs {
 
 			# iterate through options and build help output
 			local output=
-			output="${output}>> ${coloryellow}${koiname} ${FUNCNAME[1]} ${argumentshelptext}${positionalhelptext}${colorreset}\n${helptexts[$index]}\n"
+
+			# if using __koimain
+			if [[ $koisubcommands -eq 0 ]] ; then
+				local subcommandindent=">> "
+				local subcommandcmd="${FUNCNAME[1]} "
+				local subcommandhelptext="\n${helptexts[$index]}"
+			fi
+			output="${output}${subcommandindent}${coloryellow}${koiname}${subcommandcmd} ${argumentshelptext}${positionalhelptext}${colorreset}${subcommandhelptext}\n"
 			for i in "${!shortoptions[@]}" ; do
 				if [[ "${actions[$i]}" == "help" ]] ; then
 					continue
@@ -529,7 +555,10 @@ function __cleararglists {
 }
 
 function __koirun {
-	if declare -F -- "${1:-}" >/dev/null ; then
+	if declare -F -- "__koimain" >/dev/null ; then
+		koisubcommands=
+		__koimain "$@"
+	elif declare -F -- "${1:-}" >/dev/null ; then
 		"$@"
 	else
 		__errortext "$koiname: err: no such command '$1'"

--- a/koi
+++ b/koi
@@ -52,22 +52,6 @@ function help {
 	fi
 
 	# build help menu
-	local helpoutput=
-
-	# if using __koimain
-	if declare -F -- "__koimain" >/dev/null ; then
-		helpoutput=$(cat <<- EndOfHelp
-		${coloryellow}${koidescription}${colorreset}
-
-		${colorteal}Usage:${colorreset}
-		`__cleararglists ; __koimain --help`
-		EndOfHelp
-		)
-	fi
-	echo -e "$helpoutput"
-	echo
-	exit
-
 	local helpoutput=$(cat <<- EndOfHelp
 	${coloryellow}${koidescription}${colorreset}
 
@@ -434,6 +418,8 @@ function __parseargs {
 
 			# if using __koimain
 			if [[ $koisubcommands -eq 0 ]] ; then
+				output="${coloryellow}${koidescription}${colorreset}\n\n${colorteal}Usage:${colorreset}\n"
+			else
 				local subcommandindent=">> "
 				local subcommandcmd="${FUNCNAME[1]} "
 				local subcommandhelptext="\n${helptexts[$index]}"
@@ -556,7 +542,7 @@ function __cleararglists {
 
 function __koirun {
 	if declare -F -- "__koimain" >/dev/null ; then
-		koisubcommands=
+		koisubcommands=0
 		__koimain "$@"
 	elif declare -F -- "${1:-}" >/dev/null ; then
 		"$@"


### PR DESCRIPTION
Added `__koimain` functionality to run koi without subcommands. Will not implement global flags/options because I decided to not mix `__koimain` with subcommands. A work around for global flags is to simply add each "global" flag to each function that requires it with `__addarg`.